### PR TITLE
[FIX] Message when the password is not the same at Register

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -76,7 +76,7 @@ export const startRegister = (
       Swal.fire(
         "AlwaysNews",
         "Please verify that the password is the same",
-        "success"
+        "error"
       );
     };
   } else {


### PR DESCRIPTION
When the user registers and their password confirmation is wrong, a "success" alert appears